### PR TITLE
fix(media): resolve re.error due to inline flags placement in librarian_signal

### DIFF
--- a/unraid-homelab/media/librarian/librarian_signal.py
+++ b/unraid-homelab/media/librarian/librarian_signal.py
@@ -454,8 +454,8 @@ def run_bot():
                 
                 # Verify trigger prefixes (e.g., !book or !livre) to prevent normal chat/note/group spam.
                 # Prefix is strictly mandatory for both group chats and Note to Self.
-                prefix_pattern = r"^(?i)(!book|!livre)\b"
-                has_prefix = bool(re.match(prefix_pattern, text_content))
+                prefix_pattern = r"^(!book|!livre)\b"
+                has_prefix = bool(re.match(prefix_pattern, text_content, re.IGNORECASE))
                 
                 if not has_prefix:
                     # Silently ignore normal non-book related messages in chats/groups
@@ -497,7 +497,7 @@ def run_bot():
                 # Handling Text Search Query (only processed if has_prefix is True)
                 elif text_content:
                     # Extract query by stripping the prefix
-                    query = re.sub(prefix_pattern, "", text_content).strip()
+                    query = re.sub(prefix_pattern, "", text_content, flags=re.IGNORECASE).strip()
                     
                     send_signal_message(
                         f"🔍 Recherche de '{query}' en cours sur Anna's Archive...", 


### PR DESCRIPTION
## Description
Ce PR apporte le correctif essentiel pour résoudre le crash du bot Librarian lors de la réception d'un message :

- **Correction du bug Regex (`global flags not at the start...`)** :
  - Résout l'erreur Python `re.error: global flags not at the start of the expression at position 1` qui faisait crasher la boucle du bot dès la réception d'un message.
  - En Python, le drapeau inline `(?i)` ne peut pas être placé après l'ancre de début de chaîne `^`.
  - **Correction :** Suppression du drapeau inline `(?i)` et passage propre du paramètre standard `re.IGNORECASE` (ou `flags=re.IGNORECASE`) dans `re.match` et `re.sub`.

## Changements
- Correction de la regex dans `unraid-homelab/media/librarian/librarian_signal.py`.